### PR TITLE
Fix compatibility with Kitodo.Presentation 2.3.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 Templates
 Resources/Public/Css/allStyles.css.map
+.vscode

--- a/Classes/Helpers/GetDoc.php
+++ b/Classes/Helpers/GetDoc.php
@@ -103,8 +103,10 @@ class GetDoc
     $physicalStructures = $this->doc->physicalStructures;
     $physicalStructuresInfo = $this->doc->physicalStructuresInfo;
 
-    foreach ($physicalStructures as $key => $physicalPage) {
-        $map[$key] = array( 'label' => $physicalStructuresInfo[$physicalPage]['label'], 'physicalPage' => $physicalPage);
+    if (is_array($physicalStructures)) {
+        foreach ($physicalStructures as $key => $physicalPage) {
+            $map[$key] = array('label' => $physicalStructuresInfo[$physicalPage]['label'], 'physicalPage' => $physicalPage);
+        }
     }
 
     return $map;

--- a/Configuration/TypoScript/Page/header.ts
+++ b/Configuration/TypoScript/Page/header.ts
@@ -8,9 +8,8 @@ page {
 	includeCSS {
 		style = EXT:ddb_frontend_viewer/Resources/Public/Css/allStyles.css
 	}
-
-	includeJSLibs {
-		# we include jquery by t3jquery on page.9 below
+	includeJSFooterlibs {
+		# jQuery is included by Kitodo.Presentation on head of page
 		uiscripts = EXT:ddb_frontend_viewer/Resources/Public/Js/allScripts.js
 	}
 	meta {

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This TYPO3 extension provides the configuration and setup for the DDB Frontend Viewer.
 
 ##  Installation
-This extension needs to reside in a folder called `ddb_frontend_viewer` in TYPO3 extension folder ('typoconf/ext'). 
+This extension needs to reside in a folder called `ddb_frontend_viewer` in TYPO3 extension folder ('typoconf/ext').
 
 ## Frontend development (based on Grunt)
 
@@ -14,9 +14,5 @@ You can simply get it running by installing the local needings of NPM with npm i
 After that just type grunt to start the processing which watches all the LESS and JS folders to generate new asset files on the fly if anythings changes.
 
 ## Dependencies
-- TYPO3 CMS Frontend (cms)
-- CSS styled content (css_styled_content)
-- Extbase Framework (Extbase)
-- Fluid Templating Engine (fluid)
-- RealURL (realurl)
-- Kitodo.Presentatioin (dlf)
+- TYPO3 CMS Frontend (cms) 7.6.x
+- Kitodo.Presentatioin (dlf) 2.3.x

--- a/Resources/Private/Layouts/Page.html
+++ b/Resources/Private/Layouts/Page.html
@@ -1,6 +1,4 @@
-{namespace t3jquery=T3Ext\T3jquery\ViewHelpers}
 {namespace ddb=Slub\DdbFrontendViewer\ViewHelpers}
-<t3jquery:AddJQuery />
 <f:if condition="<ddb:xpath xpath='(//mets:mets/mets:structMap/mets:div/@LABEL)[1]' />">
 	<f:then>
 		<ddb:titleTag title="<ddb:xpath xpath='(//mets:mets/mets:structMap/mets:div/@LABEL)[1]' />" />
@@ -17,7 +15,7 @@
 		<!--TYPO3SEARCH_end-->
 </div>
 <script type="text/javascript">
-<!-- workaround for fiz proxy, SRU and pageselect plugin -->
+<f:comment>workaround for FIZ proxy, SRU and pageselect plugin</f:comment>
 $("form").each(function(index) {
 	var action = $(this).attr('action');
 	if (action.indexOf(window.location.protocol) == -1) {

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,28 @@
+{
+  "name": "slub/ddb-frontend-viewer",
+  "description": "Viewer based on Kitodo.Presentation, customized for DDB",
+  "type": "typo3-cms-extension",
+  "homepage": "https://github.com/Deutsche-Digitale-Bibliothek/ddb-frontend-viewer",
+  "keywords" : ["TYPO3 CMS"],
+  "license": "GPL-3.0-or-later",
+  "authors" : [
+    {
+      "name" : "Alexander Bigga",
+      "email" : "alexander.bigga@slub-dresden.de",
+      "role" : "Developer"
+    }
+  ],
+  "require": {
+      "typo3/cms-core": "^7.6"
+  },
+  "autoload": {
+      "psr-4": {
+          "Slub\\DdbFrontendViewer\\": "Classes"
+      }
+  },
+  "extra": {
+    "typo3/cms": {
+       "extension-key": "ddb_frontend_viewer"
+    }
+  }
+}

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     }
   ],
   "require": {
-      "typo3/cms-core": "^7.6"
+      "typo3/cms-core": "^7.6",
+      "kitodo/presentation": "~2.3.0"
   },
   "autoload": {
       "psr-4": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -4,17 +4,17 @@ $EM_CONF[$_EXTKEY] = array(
 	'title' => 'DDB Frontend Viewer',
 	'description' => 'Viewer based on Kitodo.Presentation, customized for DDB',
 	'category' => 'templates',
-	'version' => '0.0.2',
-	'state' => 'alpha',
+	'version' => '1.0.0',
+	'state' => 'stable',
 	'uploadfolder' => 0,
 	'clearCacheOnLoad' => 0,
 	'lockType' => '',
 	'author' => 'Alexander Bigga',
-	'author_email' => 'alexander.bigga@slub-dresden.de',
+	'author_email' => 'typo3@slub-dresden.de',
 	'constraints' => array(
 		'depends' => array(
 			'typo3' => '7.6.0-7.6.99',
-			'dlf' => '2.1.0',
+			'dlf' => '2.3.0-2.3.99',
 		),
 		'conflicts' => array(
 		),

--- a/plugins/sru/class.tx_ddbfrontendviewer_sru.php
+++ b/plugins/sru/class.tx_ddbfrontendviewer_sru.php
@@ -124,11 +124,7 @@ class tx_ddbfrontendviewer_sru extends tx_dlf_plugin {
 	protected function addSearchFormJS() {
 
 		// Add javascript to page header.
-		if (tx_dlf_helper::loadJQuery()) {
-
-			$GLOBALS['TSFE']->additionalHeaderData[$this->prefixId.'_sru'] = '<script type="text/javascript" src="'.\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'plugins/sru/tx_ddbfrontendviewer_sru.js"></script>';
-
-		}
+        $GLOBALS['TSFE']->additionalHeaderData[$this->prefixId.'_sru'] = '<script type="text/javascript" src="'.\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'plugins/sru/tx_ddbfrontendviewer_sru.js"></script>';
 
 	}
 

--- a/plugins/sru/class.tx_ddbfrontendviewer_sru_eid.php
+++ b/plugins/sru/class.tx_ddbfrontendviewer_sru_eid.php
@@ -71,7 +71,7 @@ class tx_ddbfrontendviewer_sru_eid extends \TYPO3\CMS\Frontend\Plugin\AbstractPl
 
 					$fullTextHit = $record->xpath('//srw:recordData');
 
-					$pageAttributes = '';
+					$pageAttributes = [];
 
 					foreach($fullTextHit[$id]->children('http://dfg-viewer.de/')->page->attributes() as $key => $val) {
 

--- a/plugins/sru/locallang.xml
+++ b/plugins/sru/locallang.xml
@@ -22,7 +22,7 @@
 			<label index="label.delete_search">Suche löschen</label>
 			<label index="label.loading">Lade Ergebnisse</label>
 			<label index="label.submit">Suchen</label>
-			<label index="label.noresults">Keine Ergebnissse für Ihre Suchanfrage: </label>
+			<label index="label.noresults">Keine Ergebnisse für Ihre Suchanfrage: </label>
 			<label index="search">Suche</label>
 		</languageKey>
 	</data>


### PR DESCRIPTION
This fixes the compatibility with latest 2.x release of Kitodo.Presentation.

Originally the DDB viewer was developed with Kitodo.Presentation 2.1.0. During development, some features were added to Kitodo.Presentation. But there has never been a release 2.1.1.

Release 2.2.0 of Kitodo.Presentation broke the DDB viewer as the support for `EXT:t3jquery` has been dropped.

This PR drops the support for t3jquery, too. It's compatible with Kitodo.Presentation 2.3.x only now.

Example-Link for testing the SRU-plugin on the local domain `typo3-76.ddev.site`:

https://typo3-76.ddev.site/index.php?id=1&tx_dlf%5Bpage%5D=15&tx_dlf%5Bdouble%5D=1&tx_dlf%5Bid%5D=http%3A%2F%2Fbrema.suub.uni-bremen.de%2Fbremzeit%2Foai%2F%3Fverb%3DGetRecord%26metadataPrefix%3Dmets%26identifier%3Doai%3Abrema.suub.uni-bremen.de%2Fbremzeit%3A2253168&tx_dlf%5Bpagegrid%5D=0